### PR TITLE
Fix freezing when calling `iterator.return()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ export function batchedDomMutations(target, {signal, ...options} = {}) {
 
 			signal?.addEventListener('abort', () => {
 				isDone = true;
+
 				while (resolvers.length > 0) {
 					const next = resolvers.shift();
 					next.reject(signal.reason);
@@ -42,17 +43,21 @@ export function batchedDomMutations(target, {signal, ...options} = {}) {
 					}
 
 					signal?.throwIfAborted();
+
 					return new Promise((resolve, reject) => {
 						resolvers.push({resolve, reject});
 					});
 				},
 				async return(value) {
 					isDone = true;
+
 					observer.disconnect();
+
 					return {value, done: true};
 				},
 				async throw(error) {
 					await this.return();
+
 					throw error;
 				},
 				[Symbol.asyncIterator]() {

--- a/index.js
+++ b/index.js
@@ -9,58 +9,57 @@ export default function domMutations(target, options = {}) {
 }
 
 export function batchedDomMutations(target, {signal, ...options} = {}) {
-	signal?.throwIfAborted();
-
-	const resolvers = [];
-
-	let isDone = false;
-
-	const observer = new globalThis.MutationObserver(mutations => {
-		const next = resolvers.shift();
-
-		if (next) {
-			next.resolve({value: mutations, done: false});
-		}
-	});
-
-	observer.observe(target, options);
-
-	signal?.addEventListener('abort', () => {
-		isDone = true;
-		while (resolvers.length > 0) {
-			const next = resolvers.shift();
-			next.reject(signal.reason);
-		}
-
-		observer.disconnect();
-	}, {once: true});
-
 	return {
-		async next() {
-			if (isDone) {
-				return {value: undefined, done: true};
-			}
-
+		[Symbol.asyncIterator]() {
 			signal?.throwIfAborted();
 
-			return new Promise((resolve, reject) => {
-				resolvers.push({resolve, reject});
+			const resolvers = [];
+			let isDone = false;
+
+			const observer = new globalThis.MutationObserver(mutations => {
+				const next = resolvers.shift();
+				if (next) {
+					next.resolve({value: mutations, done: false});
+				}
 			});
-		},
-		async return(value) {
-			isDone = true;
 
-			observer.disconnect();
+			observer.observe(target, options);
 
-			return {value, done: true};
-		},
-		async throw(error) {
-			await this.return();
+			signal?.addEventListener('abort', () => {
+				isDone = true;
+				while (resolvers.length > 0) {
+					const next = resolvers.shift();
+					next.reject(signal.reason);
+				}
 
-			throw error;
-		},
-		[Symbol.asyncIterator]() {
-			return this;
+				observer.disconnect();
+			}, {once: true});
+
+			const iterator = {
+				async next() {
+					if (isDone) {
+						return {value: undefined, done: true};
+					}
+
+					signal?.throwIfAborted();
+					return new Promise((resolve, reject) => {
+						resolvers.push({resolve, reject});
+					});
+				},
+				async return(value) {
+					isDone = true;
+					observer.disconnect();
+					return {value, done: true};
+				},
+				async throw(error) {
+					await this.return();
+					throw error;
+				},
+				[Symbol.asyncIterator]() {
+					return this;
+				},
+			};
+			return iterator;
 		},
 	};
 }

--- a/index.js
+++ b/index.js
@@ -12,9 +12,12 @@ export function batchedDomMutations(target, {signal, ...options} = {}) {
 	signal?.throwIfAborted();
 
 	const resolvers = [];
+
 	let isDone = false;
+
 	const observer = new globalThis.MutationObserver(mutations => {
 		const next = resolvers.shift();
+
 		if (next) {
 			next.resolve({value: mutations, done: false});
 		}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	"devDependencies": {
 		"ava": "^5.3.1",
 		"jsdom": "^24.1.1",
+		"p-state": "^2.0.1",
 		"xo": "^0.59.3"
 	},
 	"ava": {

--- a/test.js
+++ b/test.js
@@ -8,8 +8,6 @@ const {document} = window;
 globalThis.MutationObserver = window.MutationObserver;
 
 test('captures mutations', async t => {
-	document.body.innerHTML = '';
-
 	const div = document.createElement('div');
 	document.body.append(div);
 
@@ -41,8 +39,6 @@ test('captures mutations', async t => {
 });
 
 test('stops observing after disconnection', async t => {
-	document.body.innerHTML = '';
-
 	const div = document.createElement('div');
 	document.body.append(div);
 
@@ -66,8 +62,6 @@ test('stops observing after disconnection', async t => {
 });
 
 test('handles abort signal', async t => {
-	document.body.innerHTML = '';
-
 	const div = document.createElement('div');
 	document.body.append(div);
 
@@ -91,8 +85,6 @@ test('handles abort signal', async t => {
 });
 
 test('captures mutation batches', async t => {
-	document.body.innerHTML = '';
-
 	const div = document.createElement('div');
 	document.body.append(div);
 
@@ -115,4 +107,22 @@ test('captures mutation batches', async t => {
 			break;
 		}
 	}
+});
+
+test('handles calling .return()', async t => {
+	const div = document.createElement('div');
+	document.body.append(div);
+
+	const iterator = batchedDomMutations(div, {childList: true})[Symbol.asyncIterator]();
+
+	// Start asking for mutation
+	iterator.next();
+
+	iterator.return();
+
+	for await (const _ of iterator) {
+		t.fail('Iterator should be closed and not yield any values');
+	}
+
+	t.pass();
 });


### PR DESCRIPTION
Issue seems to be related to `while (true)` locking up the event loop.

We also don't bother clearing the body in the tests, since the tests aren't synchronous, so it doesn't really help.

Related to https://github.com/sindresorhus/element-ready/pull/59