### PR TITLE
Fix freezing on `return()` for `domMutations`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export default function domMutations(target, options = {}) {
 	return {
 		[Symbol.asyncIterator]() {
-			const batchedIterator = batchedDomMutations(target, options)[Symbol.asyncIterator]()
+			const batchedIterator = batchedDomMutations(target, options)[Symbol.asyncIterator]();
 
 			const iterator = (async function * () {
 				for await (const mutations of batchedIterator) {
@@ -17,13 +17,13 @@ export default function domMutations(target, options = {}) {
 					await batchedIterator.return();
 					return iterator.return();
 				},
-				async throw(err) {
-					return iterator.throw(err);
+				async throw(error) {
+					return iterator.throw(error);
 				},
 				[Symbol.asyncIterator]() {
 					return this;
 				},
-			}
+			};
 		},
 	};
 }

--- a/test.js
+++ b/test.js
@@ -129,7 +129,7 @@ test('skips mutations before next()', async t => {
 	t.is(await promiseStateAsync(nextPromise), 'pending', 'next() promise should be pending');
 });
 
-test('handles calling return()', async t => {
+test('batchedDomMutations - handles calling return()', async t => {
 	const div = document.createElement('div');
 	document.body.append(div);
 
@@ -146,3 +146,21 @@ test('handles calling return()', async t => {
 
 	t.pass();
 });
+
+test('domMutations - handles calling return()', async t => {
+	const div = document.createElement('div');
+	document.body.append(div);
+
+	const iterator = domMutations(div, {childList: true})[Symbol.asyncIterator]();
+
+	// Start asking for mutation
+	iterator.next();
+
+	iterator.return();
+
+	for await (const _ of iterator) {
+		t.fail('Iterator should be closed and not yield any values');
+	}
+
+	t.pass();
+})

--- a/test.js
+++ b/test.js
@@ -163,4 +163,4 @@ test('domMutations - handles calling return()', async t => {
 	}
 
 	t.pass();
-})
+});


### PR DESCRIPTION
It turns out this problem happens for both functions, sorry!

To fix this, we pass the `return()` signal down to the batched version, which will run the cleanup.

This solution doesn't feel idiomatic, and that's because you're not intended to manually call `.return()`. Rather, you implicitly call it when you do `return;` from within the loop, at which point a value would have needed to be produced so that the loop would run.